### PR TITLE
Migrate to next.jdbc

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [com.h2database/h2 "1.4.200"]
                  [org.clojure/java.jdbc "0.7.11"]
+                 [seancorfield/next.jdbc "1.1.569"]
                  [org.apache.derby/derby "10.14.2.0"]
                  [mysql/mysql-connector-java "8.0.20"]
                  [org.postgresql/postgresql "42.2.12"]

--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -3,7 +3,6 @@
   (:require [clojure.core.async :as async]
             [konserve.serializers :as ser]
             [hasch.core :as hasch]
-            [clojure.java.jdbc :as j]
             [next.jdbc :as jdbc]
             [next.jdbc.result-set :as rs]
             [konserve.protocols :refer [PEDNAsyncKeyValueStore
@@ -273,7 +272,7 @@
   (let [res-ch (async/chan 1)]
     (async/thread
       (try
-        (j/execute! (-> store :conn :db) [(str "drop table " (-> store :conn :table))])
+        (jdbc/execute! (-> store :conn :ds) [(str "drop table " (-> store :conn :table))])
         (async/close! res-ch)
         (catch Exception e (async/put! res-ch (prep-ex "Failed to delete store" e)))))          
     res-ch))

--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -4,6 +4,7 @@
             [konserve.serializers :as ser]
             [hasch.core :as hasch]
             [clojure.java.jdbc :as j]
+            [next.jdbc :as jdbc]
             [konserve.protocols :refer [PEDNAsyncKeyValueStore
                                         -exists? -get -get-meta
                                         -update-in -assoc-in -dissoc
@@ -42,7 +43,7 @@
 
 (defn it-exists? 
   [conn id]
-  (let [res (first (j/query (:db conn) [(str "select 1 from " (:table conn) " where id = '" id "'")]))]
+  (let [res (first (jdbc/execute! (:db conn) [(str "select 1 from " (:table conn) " where id = '" id "'")]))]
     (not (nil? res)))) 
   
 (defn get-conn [db]

--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -5,6 +5,8 @@
             [hasch.core :as hasch]
             [clojure.java.jdbc :as j]
             [next.jdbc :as jdbc]
+            [next.jdbc.prepare :as p]
+            [next.jdbc.result-set :as rs]
             [konserve.protocols :refer [PEDNAsyncKeyValueStore
                                         -exists? -get -get-meta
                                         -update-in -assoc-in -dissoc
@@ -43,7 +45,7 @@
 
 (defn it-exists? 
   [conn id]
-  (let [res (first (jdbc/execute! (:db conn) [(str "select 1 from " (:table conn) " where id = '" id "'")]))]
+  (let [res (first (jdbc/execute! (:ds conn) [(str "select 1 from " (:table conn) " where id = '" id "'")]))]
     (not (nil? res)))) 
   
 (defn get-conn [db]
@@ -54,62 +56,54 @@
 
 (defn get-it 
   [conn id]
-  (let [db (get-conn (:db conn))
-        res' (first (j/query db [(str "select * from " (:table conn) " where id = '" id "'")]))
+  (let [res' (first (jdbc/execute! (:ds conn) [(str "select * from " (:table conn) " where id = '" id "'")] {:builder-fn rs/as-unqualified-lower-maps}))
         data (:data res')
         meta (:meta res')
         res (if (and meta data)
               [(strip-version meta) (strip-version data)]
               [nil nil])]
-    (close-conn db)
     res))  
 
 (defn get-it-only
   [conn id]
-  (let [db (get-conn (:db conn))
-        res' (first (j/query db [(str "select id,data from " (:table conn) " where id = '" id "'")]))
+  (let [res' (first (jdbc/execute! (:ds conn) [(str "select id,data from " (:table conn) " where id = '" id "'")] {:builder-fn rs/as-unqualified-lower-maps}))
         data (:data res')
         res (when data (strip-version data))]
-    (close-conn db)
     res))
 
 (defn get-meta 
   [conn id]
-  (let [db (get-conn (:db conn))
-        res' (first (j/query db [(str "select id,meta from " (:table conn) " where id = '" id "'")]))
+  (let [res' (first (jdbc/execute! (:ds conn) [(str "select id,meta from " (:table conn) " where id = '" id "'")] {:builder-fn rs/as-unqualified-lower-maps}))
         meta (:meta res')
         res (when meta (strip-version meta))]
-    (close-conn db)
     res))
 
 (defn update-it 
   [conn id data]
-  (let [db (get-conn (:db conn))
-        ^Connection raw-conn (db :connection)
-        p (j/prepare-statement raw-conn (str "update " (:table conn) " set meta = ?, data = ? where id = ?"))]
-    (j/execute! (:db conn) 
-      [p (add-version (first data)) (add-version (second data)) id])
-    (close-conn db)))
+  (with-open [con (jdbc/get-connection (:ds conn))]
+    (with-open [ps (jdbc/prepare con [(str "update " (:table conn) " set meta = ?, data = ? where id = ?") 
+                                      (add-version (first data)) 
+                                      (add-version (second data)) 
+                                      id])]
+      (jdbc/execute-one! ps))))
 
 (defn insert-it 
   [conn id data]
-  (let [db (get-conn (:db conn))
-        ^Connection raw-conn (db :connection)
-        p (j/prepare-statement raw-conn (str "insert into " (:table conn) " (id,meta,data) values(?, ?, ?)"))]
-    (j/execute! (:db conn) 
-      [p id (add-version (first data)) (add-version (second data))])
-    (close-conn db)))
+  (with-open [con (jdbc/get-connection (:ds conn))]
+    (with-open [ps (jdbc/prepare con [(str "insert into " (:table conn) " (id,meta,data) values(?, ?, ?)")
+                                      id
+                                      (add-version (first data)) 
+                                      (add-version (second data))])]
+      (jdbc/execute-one! ps))))
 
 (defn delete-it 
   [conn id]
-  (j/execute! (:db conn) [(str "delete from " (:table conn) " where id = '" id "'")])) 
+  (jdbc/execute! (:ds conn) [(str "delete from " (:table conn) " where id = '" id "'")])) 
 
 (defn get-keys 
   [conn]
-  (let [db (get-conn (:db conn))
-        res' (j/query db [(str "select id,meta from " (:table conn))])
+  (let [res' (jdbc/execute! (:ds conn) [(str "select id,meta from " (:table conn))] {:builder-fn rs/as-unqualified-lower-maps})
         res (doall (map #(strip-version (:meta %)) res'))]
-    (close-conn db)
     res))
 
 
@@ -258,18 +252,19 @@
     (let [res-ch (async/chan 1)]                      
       (async/thread 
         (try
-          (let [dbtype (or (:dbtype db) (:subprotocol db))]
+          (let [dbtype (or (:dbtype db) (:subprotocol db))
+                datasource (jdbc/get-datasource db)]
             (when-not dbtype 
               (throw (ex-info ":dbtype must be explicitly declared" {:options dbtypes})))
             (case dbtype
 
               "postgresql" 
-                (j/execute! db [(str "create table if not exists " table " (id varchar(100) primary key, meta bytea, data bytea)")])
+                (jdbc/execute! datasource [(str "create table if not exists " table " (id varchar(100) primary key, meta bytea, data bytea)")])
             
-              (j/execute! db [(str "create table if not exists " table " (id varchar(100) primary key, meta longblob, data longblob)")]))
+                (jdbc/execute! datasource [(str "create table if not exists " table " (id varchar(100) primary key, meta longblob, data longblob)")]))
             
             (async/put! res-ch
-              (map->JDBCStore { :conn {:db db :table table}
+              (map->JDBCStore { :conn {:db db :table table :ds datasource}
                                 :read-handlers read-handlers
                                 :write-handlers write-handlers
                                 :serializer serializer

--- a/test/konserve_jdbc/core_h2_test.clj
+++ b/test/konserve_jdbc/core_h2_test.clj
@@ -27,10 +27,8 @@
 (use-fixtures :once my-test-fixture)
 
 (def conn 
-  { :dbtype "h2:file"
-    :classname "org.h2.Driver"
-    :subprotocol "h2:file"
-    :subname "./temp/db"
+  { :dbtype "h2"
+    :dbname "./temp/konserve;DB_CLOSE_ON_EXIT=FALSE"
     :user "sa"
     :password ""
    })
@@ -44,7 +42,8 @@
       (is (not (<!! (k/exists? store :foo))))
       (is (= :default (<!! (k/get-in store [:fuu] :default))))
       (<!! (k/bget store :foo (fn [res] 
-                                (is (nil? res))))))))
+                                (is (nil? res)))))
+      (delete-store store))))
 
 (deftest write-value-test
   (testing "Test writing to store"
@@ -268,7 +267,7 @@
   (testing "Test exception handling"
     (let [_ (println "Generating exceptions")
           store (<!! (new-jdbc-store conn :table "test_exceptions"))
-          corrupt (update-in store [:conn] #(dissoc % :db))] ; let's corrupt our store
+          corrupt (update-in store [:conn] #(dissoc % :db :ds))] ; let's corrupt our store
       (is (= ExceptionInfo (type (<!! (new-jdbc-store conn :table "")))))
       (is (= ExceptionInfo (type (<!! (k/get corrupt :bad)))))
       (is (= ExceptionInfo (type (<!! (k/get-meta corrupt :bad)))))

--- a/test/konserve_jdbc/core_postgres_test.clj
+++ b/test/konserve_jdbc/core_postgres_test.clj
@@ -1,11 +1,12 @@
 (ns konserve-jdbc.core-postgres-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.core.async :refer [<!!] :as async]
             [konserve.core :as k]
             [konserve-jdbc.core :refer [new-jdbc-store delete-store] :as kjc]
             [hasch.core :as hasch]
             [malli.generator :as mg]
-            [clojure.java.jdbc :as j])
+            [clojure.java.jdbc :as j]
+            [next.jdbc :as jdbc])
   (:import  [clojure.lang ExceptionInfo]))
 
 (def conn { :dbtype "postgresql"
@@ -14,12 +15,25 @@
             :user "konserve"
             :password "password"})
 
-(def conn2 {:dbtype "postgresql"
-            :dbname "konserve"
-            :host "localhost"
-            :user "konserve"
-            :password "password"})
+(defn reset-db [f]
+  (f)
+  (with-open [con (jdbc/get-connection conn)]
+    (jdbc/execute! con ["drop table if exists nil"])
+    (jdbc/execute! con ["drop table if exists test_write"])
+    (jdbc/execute! con ["drop table if exists test_update"])
+    (jdbc/execute! con ["drop table if exists test_exists"])
+    (jdbc/execute! con ["drop table if exists test_binary"])
+    (jdbc/execute! con ["drop table if exists test_key"])
+    (jdbc/execute! con ["drop table if exists test_append"])
+    (jdbc/execute! con ["drop table if exists test_realistic"])
+    (jdbc/execute! con ["drop table if exists test_bulk"])
+    (jdbc/execute! con ["drop table if exists test_version"])
+    (jdbc/execute! con ["drop table if exists test_serializer"])
+    (jdbc/execute! con ["drop table if exists test_compressor"])
+    (jdbc/execute! con ["drop table if exists test_encryptor"])
+    (jdbc/execute! con ["drop table if exists test_exceptions"])))
 
+(use-fixtures :once reset-db)
 
 (deftest get-nil-test
   (testing "Test getting on empty store"

--- a/test/konserve_jdbc/core_postgres_test.clj
+++ b/test/konserve_jdbc/core_postgres_test.clj
@@ -57,7 +57,8 @@
       (is (= :foo (:key (<!! (k/get-meta store :foo)))))
       (<!! (k/assoc-in store [:baz] {:bar 42}))
       (is (= 42 (<!! (k/get-in store [:baz :bar]))))
-      (delete-store store))))
+      ;(delete-store store)
+      )))
 
 (deftest update-value-test
   (testing "Test updating values in the store"
@@ -268,7 +269,7 @@
   (testing "Test exception handling"
     (let [_ (println "Generating exceptions")
           store (<!! (new-jdbc-store conn :table "test_exceptions"))
-          corrupt (update-in store [:conn] #(dissoc % :db))] ; let's corrupt our store
+          corrupt (update-in store [:conn] #(dissoc % :db :ds))] ; let's corrupt our store
       (is (= ExceptionInfo (type (<!! (new-jdbc-store "-")))))
       (is (= ExceptionInfo (type (<!! (k/get corrupt :bad)))))
       (is (= ExceptionInfo (type (<!! (k/get-meta corrupt :bad)))))


### PR DESCRIPTION
Migrate from `org.clojure/java.jdbc` to `seancorfield/next.jdbc`
- All tests passing
- Compatible with [replikativ/datahike-jdbc](https://github.com/replikativ/datahike-jdbc)